### PR TITLE
feat: ensure local backend store directory exists

### DIFF
--- a/cmd/d2ctl/cmd/root.go
+++ b/cmd/d2ctl/cmd/root.go
@@ -8,9 +8,24 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 )
+
+// StatePath stores the path to the local directory for Pulumi state.
+var StatePath string
+
+func init() {
+	// Use current user home directory as base for pulumi backend store
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	RootCmd.PersistentFlags().StringVar(&StatePath, "state-path", filepath.Join(homeDir, ".day-two-state"), "Path to store the local state")
+}
 
 // RootCmd describes the root command for argesctl.
 var RootCmd = &cobra.Command{

--- a/cmd/d2ctl/cmd/up/up.go
+++ b/cmd/d2ctl/cmd/up/up.go
@@ -32,9 +32,9 @@ func init() {
 var upCmd = &cobra.Command{
 	Use:   "up",
 	Short: "Setup helm charts",
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(cobraCmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 
-		return pulumi.Up(ctx, configPath)
+		return pulumi.Up(ctx, configPath, cmd.StatePath)
 	},
 }


### PR DESCRIPTION
Usually the 'pulumi login --local' CLI command ensures
the local backend exists before projects are created.
This is not exposed via the offical SDK so the
functionality has to be replicated in d2ctl

Signed-off-by: Tim Jones <tim.jones@siderolabs.com>