### PR TITLE
feat: deploy namespace explicitly and configure pod security

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2022-03-02T14:00:09Z by kres latest.
+# Generated on 2022-04-06T18:21:50Z by kres 8bc4139-dirty.
 
 ---
 policies:
@@ -10,7 +10,7 @@ policies:
     gpg:
       required: true
       identity:
-        gitHubOrganization: talos-systems
+        gitHubOrganization: siderolabs
     spellcheck:
       locale: US
     maximumOfOneCommit: true

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2022-03-02T14:22:48Z by kres latest.
+# Generated on 2022-04-06T18:21:50Z by kres 8bc4139-dirty.
 
 **
 !cmd
@@ -8,5 +8,6 @@
 !go.mod
 !go.sum
 !.golangci.yml
+!CHANGELOG.md
 !README.md
 !.markdownlint.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,16 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2022-03-02T14:33:20Z by kres latest.
+# Generated on 2022-04-06T18:21:50Z by kres 8bc4139-dirty.
 
 ARG TOOLCHAIN
 
 # cleaned up specs and compiled versions
 FROM scratch AS generate
 
-FROM ghcr.io/talos-systems/ca-certificates:v0.3.0-12-g90722c3 AS image-ca-certificates
+FROM ghcr.io/siderolabs/ca-certificates:v1.0.0 AS image-ca-certificates
 
-FROM ghcr.io/talos-systems/fhs:v0.3.0-12-g90722c3 AS image-fhs
+FROM ghcr.io/siderolabs/fhs:v1.0.0 AS image-fhs
 
 # runs markdownlint
 FROM node:14.8.0-alpine AS lint-markdown
@@ -19,6 +19,7 @@ RUN npm i -g markdownlint-cli@0.23.2
 RUN npm i sentences-per-line@0.2.1
 WORKDIR /src
 COPY .markdownlint.json .
+COPY ./CHANGELOG.md ./CHANGELOG.md
 COPY ./README.md ./README.md
 RUN markdownlint --ignore "CHANGELOG.md" --ignore "**/node_modules/**" --ignore '**/hack/chglog/**' --rules /node_modules/sentences-per-line/index.js .
 
@@ -88,6 +89,6 @@ ARG TARGETARCH
 COPY --from=d2ctl d2ctl-linux-${TARGETARCH} /d2ctl
 COPY --from=image-fhs / /
 COPY --from=image-ca-certificates / /
-LABEL org.opencontainers.image.source https://github.com/talos-systems/day-two
+LABEL org.opencontainers.image.source https://github.com/siderolabs/day-two
 ENTRYPOINT ["/d2ctl"]
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2022-03-02T14:33:20Z by kres latest.
+# Generated on 2022-04-06T18:21:50Z by kres 8bc4139-dirty.
 
 # common variables
 
@@ -9,7 +9,7 @@ TAG := $(shell git describe --tag --always --dirty)
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 ARTIFACTS := _out
 REGISTRY ?= ghcr.io
-USERNAME ?= talos-systems
+USERNAME ?= siderolabs
 REGISTRY_AND_USERNAME ?= $(REGISTRY)/$(USERNAME)
 GOFUMPT_VERSION ?= abc0db2c416aca0f60ea33c23c76665f6e7ba0b6
 GO_VERSION ?= 1.17
@@ -18,7 +18,7 @@ GRPC_GO_VERSION ?= 1.1.0
 GRPC_GATEWAY_VERSION ?= 2.4.0
 VTPROTOBUF_VERSION ?= 81d623a9a700ede8ef765e5ab08b3aa1f5b4d5a8
 TESTPKGS ?= ./...
-KRES_IMAGE ?= ghcr.io/talos-systems/kres:latest
+KRES_IMAGE ?= ghcr.io/siderolabs/kres:latest
 
 # docker build settings
 

--- a/hack/examples/config/config.yaml
+++ b/hack/examples/config/config.yaml
@@ -1,6 +1,7 @@
 charts:
   loki:
     namespace: loki
+    podSecurityLevel: privileged
     repo: https://grafana.github.io/helm-charts
     chart: loki-stack
     valuesPath: "/full/path/to/loki/values.yaml"
@@ -18,6 +19,7 @@ charts:
 
   metallb:
     namespace: metallb
+    podSecurityLevel: privileged
     repo: https://metallb.github.io/metallb
     chart: metallb
     valuesPath: "/full/path/to/metallb/values.yaml"

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -2,11 +2,11 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2022-03-02T14:00:09Z by kres latest.
+# Generated on 2022-04-06T18:21:50Z by kres 8bc4139-dirty.
 
 set -e
 
-RELEASE_TOOL_IMAGE="ghcr.io/talos-systems/release-tool:latest"
+RELEASE_TOOL_IMAGE="ghcr.io/siderolabs/release-tool:latest"
 
 function release-tool {
   docker pull "${RELEASE_TOOL_IMAGE}" >/dev/null

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,11 +18,12 @@ type ChartList struct {
 
 // Chart holds the Helm chart information to deploy.
 type Chart struct {
-	Namespace    string   `yaml:"namespace"`
-	Repo         string   `yaml:"repo"`
-	Chart        string   `yaml:"chart"`
-	ValuesPath   string   `yaml:"valuesPath"`
-	Dependencies []string `yaml:"depends"`
+	Namespace        string   `yaml:"namespace"`
+	PodSecurityLevel string   `yaml:"podSecurityLevel"`
+	Repo             string   `yaml:"repo"`
+	Chart            string   `yaml:"chart"`
+	ValuesPath       string   `yaml:"valuesPath"`
+	Dependencies     []string `yaml:"depends"`
 }
 
 // LoadConfig loads the configuration yaml file from a path.


### PR DESCRIPTION
Many charts deployed (Loki, Rook/Ceph, MetalLB) require 'privileged'
mode for the Pod Security, as they're not compatible with the `baseline`
policy.

Explicitly create namespaces via Pulumi and attach required labels based
on the config.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>